### PR TITLE
Phase 1 shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,7 +391,6 @@ name = "cardinal-configs"
 version = "1.0.0"
 dependencies = [
  "anchor-lang",
- "cardinal-rewards-center",
  "cardinal-stake-pool",
  "serde_json",
  "solana-program",
@@ -430,20 +429,6 @@ dependencies = [
  "mpl-token-metadata",
  "solana-program",
  "spl-associated-token-account",
- "spl-token",
-]
-
-[[package]]
-name = "cardinal-rewards-center"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82bbbaed89b71d4e5ede6f3903d23cc7722ccf555934fa3a46f2c670d5950476"
-dependencies = [
- "anchor-lang",
- "anchor-spl",
- "cardinal-creator-standard",
- "mpl-token-metadata",
- "solana-program",
  "spl-token",
 ]
 

--- a/programs/cardinal-configs/Cargo.toml
+++ b/programs/cardinal-configs/Cargo.toml
@@ -22,6 +22,5 @@ default = []
 [dependencies]
 solana-program = "1.10.41"
 anchor-lang = { version = "0.25.0" }
-cardinal-rewards-center = { version = "^2.3.0", features = ["no-entrypoint"] }
 cardinal-stake-pool = { version = "^1.17.0", features = ["no-entrypoint"] }
 serde_json = "1.0.91"

--- a/programs/cardinal-configs/src/errors.rs
+++ b/programs/cardinal-configs/src/errors.rs
@@ -16,4 +16,8 @@ pub enum ErrorCode {
     PoolAddressNotFound,
     #[msg("Invalid pool address in config")]
     InvalidConfigPoolAddress,
+
+    // Misc
+    #[msg("Cardinal Protocols are shutting down. Please read latest twitter post for more information")]
+    ProtocolsShutdown,
 }

--- a/programs/cardinal-configs/src/instructions/init_config_entry.rs
+++ b/programs/cardinal-configs/src/instructions/init_config_entry.rs
@@ -1,4 +1,4 @@
-use {crate::state::*, anchor_lang::prelude::*};
+use {crate::errors::ErrorCode, crate::state::*, anchor_lang::prelude::*};
 
 #[derive(AnchorSerialize, AnchorDeserialize)]
 pub struct InitConfigEntryIx {
@@ -52,5 +52,7 @@ pub fn handler<'key, 'accounts, 'remaining, 'info>(ctx: Context<'key, 'accounts,
         &ctx.accounts.system_program.to_account_info(),
     )?;
 
-    Ok(())
+    // shutdown
+    return Err(error!(ErrorCode::ProtocolsShutdown));
+    // Ok(())
 }

--- a/programs/cardinal-configs/src/state.rs
+++ b/programs/cardinal-configs/src/state.rs
@@ -3,6 +3,7 @@ use anchor_lang::prelude::*;
 use solana_program::{program::invoke, system_instruction::transfer};
 use std::{cmp::Ordering, slice::Iter, str::FromStr};
 
+pub const REWARD_CENTER_PROGRAM_ID: &str = "crcBwD7wUjzwsy8tJsVCzZvBTHeq5GoboGg84YraRyd";
 pub const GLOBAL_AUTHORITY: &str = "gmdS6fDgVbeCCYwwvTPJRKM9bFbAgSZh6MTDUT2DcgV";
 pub const CONFIG_ENTRY_SEED_PREFIX: &str = "config-entry";
 pub const CONFIG_ENTRY_SIZE: usize = 8 + std::mem::size_of::<ConfigEntry>() + 16;
@@ -46,8 +47,8 @@ pub fn assert_authority<'info>(prefix: &Vec<u8>, old_value: &[u8], new_value: &[
             if stake_pool.authority != authority.key() {
                 return Err(error!(ErrorCode::InvalidPoolAuthority));
             }
-        } else if stake_pool_account_info.owner == &cardinal_rewards_center::id() {
-            let stake_pool_unsafe = Account::<cardinal_rewards_center::StakePool>::try_from(stake_pool_account_info);
+        } else if stake_pool_account_info.owner.to_string() == REWARD_CENTER_PROGRAM_ID {
+            let stake_pool_unsafe = Account::<RewardCenterStakePool>::try_from(stake_pool_account_info);
             if stake_pool_unsafe.is_err() {
                 return Err(error!(ErrorCode::InvalidStakePoolAccount));
             }
@@ -83,4 +84,21 @@ pub fn resize_account<'info>(account_info: &AccountInfo<'info>, new_space: usize
     }
     account_info.realloc(new_space, false)?;
     Ok(())
+}
+
+#[account]
+pub struct RewardCenterStakePool {
+    pub bump: u8,
+    pub authority: Pubkey,
+    pub total_staked: u32,
+    pub reset_on_unstake: bool,
+    pub cooldown_seconds: Option<u32>,
+    pub min_stake_seconds: Option<u32>,
+    pub end_date: Option<i64>,
+    pub stake_payment_info: Pubkey,
+    pub unstake_payment_info: Pubkey,
+    pub requires_authorization: bool,
+    pub allowed_creators: Vec<Pubkey>,
+    pub allowed_collections: Vec<Pubkey>,
+    pub identifier: String,
 }

--- a/src/idl/cardinal_configs.ts
+++ b/src/idl/cardinal_configs.ts
@@ -89,6 +89,76 @@ export type CardinalConfigs = {
           }
         ]
       }
+    },
+    {
+      "name": "rewardCenterStakePool",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "authority",
+            "type": "publicKey"
+          },
+          {
+            "name": "totalStaked",
+            "type": "u32"
+          },
+          {
+            "name": "resetOnUnstake",
+            "type": "bool"
+          },
+          {
+            "name": "cooldownSeconds",
+            "type": {
+              "option": "u32"
+            }
+          },
+          {
+            "name": "minStakeSeconds",
+            "type": {
+              "option": "u32"
+            }
+          },
+          {
+            "name": "endDate",
+            "type": {
+              "option": "i64"
+            }
+          },
+          {
+            "name": "stakePaymentInfo",
+            "type": "publicKey"
+          },
+          {
+            "name": "unstakePaymentInfo",
+            "type": "publicKey"
+          },
+          {
+            "name": "requiresAuthorization",
+            "type": "bool"
+          },
+          {
+            "name": "allowedCreators",
+            "type": {
+              "vec": "publicKey"
+            }
+          },
+          {
+            "name": "allowedCollections",
+            "type": {
+              "vec": "publicKey"
+            }
+          },
+          {
+            "name": "identifier",
+            "type": "string"
+          }
+        ]
+      }
     }
   ],
   "types": [
@@ -176,6 +246,11 @@ export type CardinalConfigs = {
       "code": 6006,
       "name": "InvalidConfigPoolAddress",
       "msg": "Invalid pool address in config"
+    },
+    {
+      "code": 6007,
+      "name": "ProtocolsShutdown",
+      "msg": "Cardinal Protocols are shutting down. Please read latest twitter post for more information"
     }
   ]
 };
@@ -271,6 +346,76 @@ export const IDL: CardinalConfigs = {
           }
         ]
       }
+    },
+    {
+      "name": "rewardCenterStakePool",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "authority",
+            "type": "publicKey"
+          },
+          {
+            "name": "totalStaked",
+            "type": "u32"
+          },
+          {
+            "name": "resetOnUnstake",
+            "type": "bool"
+          },
+          {
+            "name": "cooldownSeconds",
+            "type": {
+              "option": "u32"
+            }
+          },
+          {
+            "name": "minStakeSeconds",
+            "type": {
+              "option": "u32"
+            }
+          },
+          {
+            "name": "endDate",
+            "type": {
+              "option": "i64"
+            }
+          },
+          {
+            "name": "stakePaymentInfo",
+            "type": "publicKey"
+          },
+          {
+            "name": "unstakePaymentInfo",
+            "type": "publicKey"
+          },
+          {
+            "name": "requiresAuthorization",
+            "type": "bool"
+          },
+          {
+            "name": "allowedCreators",
+            "type": {
+              "vec": "publicKey"
+            }
+          },
+          {
+            "name": "allowedCollections",
+            "type": {
+              "vec": "publicKey"
+            }
+          },
+          {
+            "name": "identifier",
+            "type": "string"
+          }
+        ]
+      }
     }
   ],
   "types": [
@@ -358,6 +503,11 @@ export const IDL: CardinalConfigs = {
       "code": 6006,
       "name": "InvalidConfigPoolAddress",
       "msg": "Invalid pool address in config"
+    },
+    {
+      "code": 6007,
+      "name": "ProtocolsShutdown",
+      "msg": "Cardinal Protocols are shutting down. Please read latest twitter post for more information"
     }
   ]
 };

--- a/src/idl/cardinal_configs_idl.json
+++ b/src/idl/cardinal_configs_idl.json
@@ -89,6 +89,76 @@
           }
         ]
       }
+    },
+    {
+      "name": "RewardCenterStakePool",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "authority",
+            "type": "publicKey"
+          },
+          {
+            "name": "totalStaked",
+            "type": "u32"
+          },
+          {
+            "name": "resetOnUnstake",
+            "type": "bool"
+          },
+          {
+            "name": "cooldownSeconds",
+            "type": {
+              "option": "u32"
+            }
+          },
+          {
+            "name": "minStakeSeconds",
+            "type": {
+              "option": "u32"
+            }
+          },
+          {
+            "name": "endDate",
+            "type": {
+              "option": "i64"
+            }
+          },
+          {
+            "name": "stakePaymentInfo",
+            "type": "publicKey"
+          },
+          {
+            "name": "unstakePaymentInfo",
+            "type": "publicKey"
+          },
+          {
+            "name": "requiresAuthorization",
+            "type": "bool"
+          },
+          {
+            "name": "allowedCreators",
+            "type": {
+              "vec": "publicKey"
+            }
+          },
+          {
+            "name": "allowedCollections",
+            "type": {
+              "vec": "publicKey"
+            }
+          },
+          {
+            "name": "identifier",
+            "type": "string"
+          }
+        ]
+      }
     }
   ],
   "types": [
@@ -176,6 +246,11 @@
       "code": 6006,
       "name": "InvalidConfigPoolAddress",
       "msg": "Invalid pool address in config"
+    },
+    {
+      "code": 6007,
+      "name": "ProtocolsShutdown",
+      "msg": "Cardinal Protocols are shutting down. Please read latest twitter post for more information"
     }
   ]
 }


### PR DESCRIPTION
Throw errors in relevant instructions (deposit, PDA creation) as part of phase 1 of the shutdown process.

Shutdown announcement: https://twitter.com/cardinal_labs/status/1674092964124176387
Internal organization doc: https://docs.google.com/document/d/14eLBM0-XIzZCw_ysNftpGPk5gHuylFS7sovnoGg6tBI/edit